### PR TITLE
Feature/multi threaded scheduling

### DIFF
--- a/examples/scheduling/mt-scheduler/build.gradle
+++ b/examples/scheduling/mt-scheduler/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id 'application'
+}
+
+dependencies {
+    implementation project(':flashlib.core.scheduling')
+}
+
+mainClassName = 'example.Main'

--- a/examples/scheduling/mt-scheduler/src/main/java/example/Main.java
+++ b/examples/scheduling/mt-scheduler/src/main/java/example/Main.java
@@ -1,0 +1,83 @@
+package example;
+
+import com.flash3388.flashlib.global.GlobalDependencies;
+import com.flash3388.flashlib.scheduling.SchedulerMode;
+import com.flash3388.flashlib.scheduling.actions.Action;
+import com.flash3388.flashlib.scheduling.actions.ActionBase;
+import com.flash3388.flashlib.scheduling.mt.MtExecutorServiceWorkers;
+import com.flash3388.flashlib.scheduling.mt.MultiThreadedScheduler;
+import com.flash3388.flashlib.time.Clock;
+import com.flash3388.flashlib.time.SystemNanoClock;
+import com.flash3388.flashlib.time.Time;
+import com.flash3388.flashlib.util.logging.LogLevel;
+import com.flash3388.flashlib.util.logging.LoggerBuilder;
+import org.slf4j.Logger;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class Main {
+
+    public static void main(String[] args) throws InterruptedException {
+        final int WORKER_COUNT = 2;
+        final SchedulerMode RUN_MODE = new SchedulerMode() {
+            @Override
+            public boolean isDisabled() {
+                return false;
+            }
+        };
+
+        ExecutorService executorService = Executors.newFixedThreadPool(WORKER_COUNT);
+        try {
+            Clock clock = new SystemNanoClock();
+            Logger logger = new LoggerBuilder("example")
+                    .enableConsoleLogging(true)
+                    .setLogLevel(LogLevel.DEBUG)
+                    .build();
+
+            try (MultiThreadedScheduler scheduler = new MultiThreadedScheduler(
+                    new MtExecutorServiceWorkers(executorService, WORKER_COUNT),
+                    clock,
+                    logger)) {
+                GlobalDependencies.setClockInstance(clock);
+                GlobalDependencies.setSchedulerInstance(scheduler);
+
+                Action action = new ActionBase() {
+                    @Override
+                    public void execute() {
+
+                    }
+                };
+                action.configure()
+                        .setName("Basic Action")
+                        .setTimeout(Time.milliseconds(500))
+                        .save();
+                action.start();
+
+                Action action1 = new ActionBase() {
+                    @Override
+                    public void execute() {
+
+                    }
+                };
+                action1.configure()
+                        .setName("Action to Cancel")
+                        .save();
+                action1.start();
+
+                Time startTime = clock.currentTime();
+                Time runTime = Time.seconds(10);
+                while (clock.currentTime().sub(startTime).lessThan(runTime)) {
+                    scheduler.run(RUN_MODE);
+                    Thread.sleep(100);
+
+                    if (action1.isRunning()) {
+                        action1.cancel();
+                    }
+                }
+            }
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+}

--- a/flashlib.core.scheduling/src/main/java/com/flash3388/flashlib/scheduling/actions/ActionContext.java
+++ b/flashlib.core.scheduling/src/main/java/com/flash3388/flashlib/scheduling/actions/ActionContext.java
@@ -25,6 +25,10 @@ public class ActionContext {
         mIsInitialized = false;
     }
 
+    public boolean isCanceled() {
+        return mActionState.isCanceled();
+    }
+
     public void prepareForRun() {
         mActionState.markStarted();
 
@@ -91,5 +95,14 @@ public class ActionContext {
         }
 
         return getRunTime().after(mTimeout);
+    }
+
+    public Action getAction() {
+        return mAction;
+    }
+
+    @Override
+    public String toString() {
+        return mAction.toString();
     }
 }

--- a/flashlib.core.scheduling/src/main/java/com/flash3388/flashlib/scheduling/mt/MtActionsControl.java
+++ b/flashlib.core.scheduling/src/main/java/com/flash3388/flashlib/scheduling/mt/MtActionsControl.java
@@ -1,0 +1,150 @@
+package com.flash3388.flashlib.scheduling.mt;
+
+import com.flash3388.flashlib.scheduling.actions.Action;
+import com.flash3388.flashlib.scheduling.actions.ActionContext;
+import com.flash3388.flashlib.time.Clock;
+import com.flash3388.flashlib.time.Time;
+import org.slf4j.Logger;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Predicate;
+
+public class MtActionsControl {
+
+    private final MtRequirementsControl mRequirementsControl;
+    private final Clock mClock;
+    private final Logger mLogger;
+
+    private final Map<Action, ActionContext> mRunningActions;
+    private final Queue<ActionContext> mRunningActionsContexts;
+    private final Queue<ActionContext> mFinishedActionsContexts;
+
+    MtActionsControl(MtRequirementsControl requirementsControl, Clock clock, Logger logger,
+                     Map<Action, ActionContext> runningActions,
+                     Queue<ActionContext> runningActionsContexts,
+                     Queue<ActionContext> finishedActionsContexts) {
+        mRequirementsControl = requirementsControl;
+        mClock = clock;
+        mLogger = logger;
+
+        mRunningActions = runningActions;
+        mRunningActionsContexts = runningActionsContexts;
+        mFinishedActionsContexts = finishedActionsContexts;
+    }
+
+    public MtActionsControl(MtRequirementsControl requirementsControl, Clock clock, Logger logger) {
+        this(requirementsControl, clock, logger,
+                new HashMap<>(5),
+                new LinkedBlockingQueue<>(5),
+                new LinkedBlockingQueue<>(5));
+    }
+
+    public void startActions(Collection<Action> actions) {
+        for (Action action : actions) {
+            onActionStart(action);
+        }
+    }
+
+    public void cancelAction(Action action) {
+        ActionContext context = mRunningActions.get(action);
+        if (context != null) {
+            context.markCanceled();
+            mRunningActionsContexts.remove(context);
+            mFinishedActionsContexts.add(context);
+        } else {
+            throw new IllegalStateException("action not running");
+        }
+    }
+
+    public void cancelActionsIf(Predicate<? super Action> predicate) {
+        for (Action action : mRunningActions.keySet()) {
+            if (predicate.test(action)) {
+                cancelAction(action);
+            }
+        }
+    }
+
+    public void cancelAllActions() {
+        for (Action action : mRunningActions.keySet()) {
+            cancelAction(action);
+        }
+    }
+
+    public boolean isActionRunning(Action action) {
+        return mRunningActions.containsKey(action);
+    }
+
+    public Time getActionRunTime(Action action) {
+        ActionContext context = mRunningActions.get(action);
+        if (context != null) {
+            return context.getRunTime();
+        } else {
+            throw new IllegalStateException("action not running");
+        }
+    }
+
+    public ActionContext pollRunningAction() {
+        return mRunningActionsContexts.poll();
+    }
+
+    public void pushRunningAction(ActionContext context) {
+        mRunningActionsContexts.add(context);
+    }
+
+    public void pushFinishedAction(ActionContext context) {
+        mFinishedActionsContexts.add(context);
+    }
+
+    public void processFinishedActions() {
+        while (!mFinishedActionsContexts.isEmpty()) {
+            ActionContext context = mFinishedActionsContexts.poll();
+            if (context == null) {
+                break;
+            }
+
+            if (mRunningActions.remove(context.getAction()) != null) {
+                onActionFinished(context, true);
+            }
+        }
+    }
+
+    private void onActionStart(Action action) {
+        if (mRunningActions.containsKey(action)) {
+            mLogger.debug("Attempted to start action {} when already running", action);
+            return;
+        }
+
+        Set<Action> conflictingActions = mRequirementsControl.updateRequirementsWithNewRunningAction(action);
+        conflictingActions.forEach((conflictingAction)-> {
+            ActionContext context = mRunningActions.remove(conflictingAction);
+            if (context != null) {
+                context.markCanceled();
+                onActionFinished(context, false);
+            }
+        });
+
+        ActionContext context = new ActionContext(action, mClock);
+        context.prepareForRun();
+
+        mRunningActions.put(action, context);
+        mRunningActionsContexts.add(context);
+
+        mLogger.debug("Started action {}", action);
+    }
+
+    private void onActionFinished(ActionContext context, boolean updateRequirements) {
+        Action action = context.getAction();
+
+        context.runFinished();
+        if (updateRequirements) {
+            mRequirementsControl.updateRequirementsNoCurrentAction(action);
+        }
+
+        mLogger.debug("Finished action {}", action);
+    }
+}

--- a/flashlib.core.scheduling/src/main/java/com/flash3388/flashlib/scheduling/mt/MtDaemonThreadWorkers.java
+++ b/flashlib.core.scheduling/src/main/java/com/flash3388/flashlib/scheduling/mt/MtDaemonThreadWorkers.java
@@ -1,0 +1,49 @@
+package com.flash3388.flashlib.scheduling.mt;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class MtDaemonThreadWorkers implements MtWorkers {
+
+    private final Function<Runnable, Thread> mWorkerFactory;
+    private final int mWorkerCount;
+    private final Set<Thread> mThreads;
+
+    public MtDaemonThreadWorkers(Function<Runnable, Thread> workerFactory, int workerCount) {
+        mWorkerFactory = workerFactory;
+        mWorkerCount = workerCount;
+        mThreads = new HashSet<>();
+    }
+
+    public MtDaemonThreadWorkers(ThreadGroup group, String threadName, int workerCount) {
+        this((task)-> new Thread(group, task, threadName), workerCount);
+    }
+
+    public MtDaemonThreadWorkers(int workerCount) {
+        this(new ThreadGroup("mt-scheduler"), "mt-scheduler-worker", workerCount);
+    }
+
+    @Override
+    public void runWorkers(Supplier<Runnable> taskSupplier) {
+        for (int i = 0; i < mWorkerCount; i++) {
+            Runnable task = taskSupplier.get();
+
+            Thread thread = mWorkerFactory.apply(task);
+            thread.setDaemon(true);
+            mThreads.add(thread);
+
+            thread.start();
+        }
+    }
+
+    @Override
+    public void stopWorkers() {
+        for (Thread thread : mThreads) {
+            thread.interrupt();
+        }
+
+        mThreads.clear();
+    }
+}

--- a/flashlib.core.scheduling/src/main/java/com/flash3388/flashlib/scheduling/mt/MtExecutorServiceWorkers.java
+++ b/flashlib.core.scheduling/src/main/java/com/flash3388/flashlib/scheduling/mt/MtExecutorServiceWorkers.java
@@ -1,0 +1,39 @@
+package com.flash3388.flashlib.scheduling.mt;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.function.Supplier;
+
+public class MtExecutorServiceWorkers implements MtWorkers {
+
+    private final ExecutorService mExecutorService;
+    private final int mWorkerCount;
+    private final Set<Future<?>> mFutures;
+
+    public MtExecutorServiceWorkers(ExecutorService executorService, int workerCount) {
+        mExecutorService = executorService;
+        mWorkerCount = workerCount;
+
+        mFutures = new HashSet<>();
+    }
+
+    @Override
+    public void runWorkers(Supplier<Runnable> taskSupplier) {
+        for (int i = 0; i < mWorkerCount; i++) {
+            Runnable runnable = taskSupplier.get();
+            Future<?> future = mExecutorService.submit(runnable);
+            mFutures.add(future);
+        }
+    }
+
+    @Override
+    public void stopWorkers() {
+        for (Future<?> future : mFutures) {
+            future.cancel(true);
+        }
+
+        mFutures.clear();
+    }
+}

--- a/flashlib.core.scheduling/src/main/java/com/flash3388/flashlib/scheduling/mt/MtRequirementsControl.java
+++ b/flashlib.core.scheduling/src/main/java/com/flash3388/flashlib/scheduling/mt/MtRequirementsControl.java
@@ -1,0 +1,83 @@
+package com.flash3388.flashlib.scheduling.mt;
+
+import com.flash3388.flashlib.scheduling.Requirement;
+import com.flash3388.flashlib.scheduling.Subsystem;
+import com.flash3388.flashlib.scheduling.actions.Action;
+import org.slf4j.Logger;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class MtRequirementsControl {
+
+    private final Logger mLogger;
+
+    private final Map<Requirement, Action> mActionsOnRequirement;
+    private final Map<Subsystem, Action> mDefaultActionsOnSubsystems;
+
+    MtRequirementsControl(Logger logger, Map<Requirement, Action> actionsOnRequirement, Map<Subsystem, Action> defaultActionsOnSubsystems) {
+        mLogger = logger;
+        mActionsOnRequirement = actionsOnRequirement;
+        mDefaultActionsOnSubsystems = defaultActionsOnSubsystems;
+    }
+
+    public MtRequirementsControl(Logger logger) {
+        this(logger, new HashMap<>(5), new HashMap<>(5));
+    }
+
+    public void updateRequirementsNoCurrentAction(Action action) {
+        for (Requirement requirement : action.getConfiguration().getRequirements()) {
+            mActionsOnRequirement.remove(requirement);
+        }
+    }
+
+    public Set<Action> updateRequirementsWithNewRunningAction(Action action) {
+        Set<Action> conflictingActions = new HashSet<>();
+
+        for (Requirement requirement : action.getConfiguration().getRequirements()) {
+            if (mActionsOnRequirement.containsKey(requirement)) {
+                Action currentAction = mActionsOnRequirement.get(requirement);
+                conflictingActions.add(currentAction);
+
+                mLogger.warn("Requirements conflict in Scheduler between {} and new action {} over requirement {}",
+                        currentAction.toString(), action.toString(), requirement.toString());
+            }
+
+            mActionsOnRequirement.put(requirement, action);
+        }
+
+        return conflictingActions;
+    }
+
+    public Optional<Action> getActionOnRequirement(Requirement requirement) {
+        return Optional.ofNullable(mActionsOnRequirement.get(requirement));
+    }
+
+    public void setDefaultActionOnSubsystem(Subsystem subsystem, Action action) {
+        if (!action.getConfiguration().getRequirements().contains(subsystem)) {
+            throw new IllegalArgumentException("Action should require the default subsystem");
+        }
+
+        Action old = mDefaultActionsOnSubsystems.put(subsystem, action);
+        if (old != null && old.isRunning()) {
+            old.cancel();
+        }
+    }
+
+    public Map<Subsystem, Action> getDefaultActionsToStart() {
+        Map<Subsystem, Action> actionsToStart = new HashMap<>();
+
+        for (Map.Entry<Subsystem, Action> entry : mDefaultActionsOnSubsystems.entrySet()) {
+            if (mActionsOnRequirement.containsKey(entry.getKey())) {
+                continue;
+            }
+
+            actionsToStart.put(entry.getKey(), entry.getValue());
+        }
+
+        return actionsToStart;
+    }
+}

--- a/flashlib.core.scheduling/src/main/java/com/flash3388/flashlib/scheduling/mt/MtSchedulerWorker.java
+++ b/flashlib.core.scheduling/src/main/java/com/flash3388/flashlib/scheduling/mt/MtSchedulerWorker.java
@@ -1,0 +1,55 @@
+package com.flash3388.flashlib.scheduling.mt;
+
+import com.beans.Property;
+import com.flash3388.flashlib.scheduling.SchedulerMode;
+import com.flash3388.flashlib.scheduling.actions.ActionContext;
+import org.slf4j.Logger;
+
+public class MtSchedulerWorker implements Runnable {
+
+    private final MtActionsControl mControl;
+    private final Property<SchedulerMode> mCurrentMode;
+    private final Logger mLogger;
+
+    public MtSchedulerWorker(MtActionsControl control, Property<SchedulerMode> currentMode,
+                             Logger logger) {
+        mControl = control;
+        mCurrentMode = currentMode;
+        mLogger = logger;
+    }
+
+    @Override
+    public void run() {
+        while (!Thread.interrupted()) {
+            SchedulerMode mode = mCurrentMode.get();
+            if (mode == null) {
+                Thread.yield();
+                continue;
+            }
+
+            ActionContext context = mControl.pollRunningAction();
+            if (context == null || context.isCanceled()) {
+                continue;
+            }
+
+            try {
+                if (mode.isDisabled() && !context.runWhenDisabled()) {
+                    context.markCanceled();
+                    mControl.pushFinishedAction(context);
+                    mLogger.debug("Action {} running in disabled. Canceling", context);
+                    continue;
+                }
+
+                if (!context.run()) {
+                    mControl.pushFinishedAction(context);
+                } else {
+                    mControl.pushRunningAction(context);
+                }
+            } catch (Throwable t) {
+                mLogger.error("Error while running an action", t);
+                context.markCanceled();
+                mControl.pushFinishedAction(context);
+            }
+        }
+    }
+}

--- a/flashlib.core.scheduling/src/main/java/com/flash3388/flashlib/scheduling/mt/MtWorkers.java
+++ b/flashlib.core.scheduling/src/main/java/com/flash3388/flashlib/scheduling/mt/MtWorkers.java
@@ -1,0 +1,9 @@
+package com.flash3388.flashlib.scheduling.mt;
+
+import java.util.function.Supplier;
+
+public interface MtWorkers {
+
+    void runWorkers(Supplier<Runnable> taskSupplier);
+    void stopWorkers();
+}

--- a/flashlib.core.scheduling/src/main/java/com/flash3388/flashlib/scheduling/mt/MultiThreadedScheduler.java
+++ b/flashlib.core.scheduling/src/main/java/com/flash3388/flashlib/scheduling/mt/MultiThreadedScheduler.java
@@ -1,0 +1,163 @@
+package com.flash3388.flashlib.scheduling.mt;
+
+import com.beans.Property;
+import com.beans.properties.atomic.AtomicProperty;
+import com.flash3388.flashlib.scheduling.Requirement;
+import com.flash3388.flashlib.scheduling.Scheduler;
+import com.flash3388.flashlib.scheduling.SchedulerMode;
+import com.flash3388.flashlib.scheduling.Subsystem;
+import com.flash3388.flashlib.scheduling.actions.Action;
+import com.flash3388.flashlib.time.Clock;
+import com.flash3388.flashlib.time.Time;
+import com.flash3388.flashlib.util.logging.Logging;
+import org.slf4j.Logger;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
+public class MultiThreadedScheduler implements Scheduler, AutoCloseable {
+
+    private static final int DEFAULT_WORKER_COUNT = 3;
+
+    private final MtWorkers mWorkersControl;
+    private final Logger mLogger;
+
+    private final MtRequirementsControl mRequirementsControl;
+    private final MtActionsControl mActionsControl;
+    private final Property<SchedulerMode> mCurrentMode;
+    private final Set<Action> mActionsToStart;
+
+    MultiThreadedScheduler(MtWorkers workersControl, Logger logger,
+                                  MtRequirementsControl requirementsControl, MtActionsControl actionsControl,
+                                  Property<SchedulerMode> currentMode, Set<Action> actionsToStart) {
+        mWorkersControl = workersControl;
+        mLogger = logger;
+        mRequirementsControl = requirementsControl;
+        mActionsControl = actionsControl;
+        mCurrentMode = currentMode;
+        mActionsToStart = actionsToStart;
+
+        mWorkersControl.runWorkers(()-> new MtSchedulerWorker(mActionsControl, mCurrentMode, mLogger));
+    }
+
+    public MultiThreadedScheduler(MtWorkers workersControl, Clock clock, Logger logger) {
+        mWorkersControl = workersControl;
+        mLogger = logger;
+        mRequirementsControl = new MtRequirementsControl(logger);
+        mActionsControl = new MtActionsControl(mRequirementsControl, clock, logger);
+        mCurrentMode = new AtomicProperty<>();
+        mActionsToStart = new HashSet<>();
+
+        mWorkersControl.runWorkers(()-> new MtSchedulerWorker(mActionsControl, mCurrentMode, mLogger));
+    }
+
+    public MultiThreadedScheduler(Clock clock, Logger logger) {
+        this(new MtDaemonThreadWorkers(DEFAULT_WORKER_COUNT), clock, logger);
+    }
+
+    public MultiThreadedScheduler(Clock clock) {
+        this(clock, Logging.stub());
+    }
+
+    @Override
+    public void start(Action action) {
+        Objects.requireNonNull(action, "action is null");
+
+        mActionsToStart.add(action);
+    }
+
+    @Override
+    public void cancel(Action action) {
+        Objects.requireNonNull(action, "action is null");
+
+        if(!mActionsToStart.remove(action)) {
+            mActionsControl.cancelAction(action);
+        }
+    }
+
+    @Override
+    public boolean isRunning(Action action) {
+        Objects.requireNonNull(action, "action is null");
+
+        return mActionsToStart.contains(action) ||
+                mActionsControl.isActionRunning(action);
+    }
+
+    @Override
+    public Time getActionRunTime(Action action) {
+        Objects.requireNonNull(action, "action is null");
+
+        if (mActionsToStart.contains(action)) {
+            return Time.milliseconds(0);
+        }
+
+        return mActionsControl.getActionRunTime(action);
+    }
+
+    @Override
+    public void cancelActionsIf(Predicate<? super Action> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+
+        mActionsToStart.removeIf(predicate);
+        mActionsControl.cancelActionsIf(predicate);
+    }
+
+    @Override
+    public void cancelAllActions() {
+        mActionsToStart.clear();
+        mActionsControl.cancelAllActions();
+    }
+
+    @Override
+    public void setDefaultAction(Subsystem subsystem, Action action) {
+        Objects.requireNonNull(subsystem, "subsystem is null");
+        Objects.requireNonNull(action, "action is null");
+
+        mRequirementsControl.setDefaultActionOnSubsystem(subsystem, action);
+    }
+
+    @Override
+    public Optional<Action> getActionRunningOnRequirement(Requirement requirement) {
+        Objects.requireNonNull(requirement, "requirement is null");
+        return mRequirementsControl.getActionOnRequirement(requirement);
+    }
+
+    @Override
+    public void run(SchedulerMode mode) {
+        mCurrentMode.set(mode);
+
+        mActionsControl.processFinishedActions();
+
+        mActionsControl.startActions(mActionsToStart);
+        mActionsToStart.clear();
+
+        startDefaultActions(mode);
+    }
+
+    @Override
+    public void close() {
+        mWorkersControl.stopWorkers();
+    }
+
+    private void startDefaultActions(SchedulerMode mode) {
+        for (Map.Entry<Subsystem, Action> entry : mRequirementsControl.getDefaultActionsToStart().entrySet()) {
+            try {
+                Action action = entry.getValue();
+
+                if (mode.isDisabled() &&
+                        !action.getConfiguration().shouldRunWhenDisabled()) {
+                    continue;
+                }
+
+                mLogger.debug("Starting default action for {}", entry.getKey());
+                action.start();
+            } catch (Throwable t) {
+                mLogger.error("Error when starting default action", t);
+            }
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,8 @@ include 'examples:robot:basic-robot'
 include 'examples:robot:robot-manual-mode-control'
 include 'examples:robot:basic-trigger'
 
+include 'examples:scheduling:mt-scheduler'
+
 include 'examples:vision:basic-vision'
 include 'examples:vision:cv-2020-vision'
 include 'examples:vision:cv-colorfilter'


### PR DESCRIPTION
An implementation of `Scheduler` which uses workers executing in a separate thread to run actions.

Still requires more testing.  

When considering the _roboRIO_ as a platform (which contains an _dual-core ARM Cortext-A9_), this may not provide much since it only has 2 cores and it is quite likely that there are enough threads (and other processes) executing on the system.

A lot of the implementation depends on cache coherency being maintained across multiple cores. This can be traced to 2 reasons:
- state classes used by the scheduler (like `ActionContext` or `ActionState`)
- and state used in implementations of actions by users

According to [developer.arm.com](https://developer.arm.com/documentation/ddi0407/i/introduction/mpcore-considerations/about-cortex-a9-mpcore-coherency)
> Memory coherency in a Cortex-A9 MPCore processor is maintained following a weakly ordered memory consistency model.
Cache coherency among L1 data caches of the Cortex-A9 processors in the cluster is maintained when the Cortex-A9 processors are operating in Symmetric Multi-Processing (SMP) mode. This mode is controlled by the SMP bit of the Auxiliary Control Register.
To be kept coherent, the memory must be marked as Write-Back, Shareable, Normal memory.

### Concept

The idea is pretty straight forward. The scheduler manages several workers, each running in a separate thread, which is a simple daemon. 

At any given moment, a worker handles one action, grabbing it from a shared work queue. That action is handled by executing a single cycle (`ActionContext.run`). If the action is finished, it is inserted into a shared finished queue. Otherwise, it is inserted into the shared work queue to be handled again.

In order to properly synchronize requirements usage, actually starting and finishing actions is done in the _main thread_ of the robot (which is used to run `Scheduler.run`).
`Scheduler.run` is used to 
- handle actions in the finished queue (update requirement usage, remove actions and such)
- place actions into the the work queue
- start registered default actions if possible